### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ src='https://raw.githubusercontent.com/mukeshthawani/TriLabelView/master/graphic
 <img
 src='https://raw.githubusercontent.com/mukeshthawani/TriLabelView/master/graphics/second_example.png' width='450' alt='TriLabelView'>
 
-## Setup with Cocoapods
+## Setup with CocoaPods
 
-If you are using Cocoapods add this text to your Podfile
+If you are using CocoaPods add this text to your Podfile
 and run `pod install`.
 
     use_frameworks!


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
